### PR TITLE
feat: scrap all sites

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,14 @@
 # Padel-Tavernes
 
-This is a Flask api that scrapes the [Esport En Tavernes Blanques](https://www.esportentavernesblanques.es/) website to get the padel (and other sports) reservations.
-As the website is quite a mess, the api returns a json with the reservations for the next 7 days, grouped by day and hour allowing to filter by sport, availability and day to avoid the noise.
+Originally this was a Flask api that scraped the [Esport En Tavernes Blanques](https://www.esportentavernesblanques.es/) website to get the padel (and other sports) bookings.
+Currently it scrapes all the known websites from [Webs de padel](https://www.websdepadel.com/) platform that allows to find the available courts to play padel in one place. So the project name is already outdated, 🥳.
 
-Also I tested this with other similar websites from [Webs de padel](https://www.websdepadel.com/) and it works mostly in every one, so I added a parameter to the api to change the website to scrape. (Project name outdated in less than a day, 🥳)
+The scraped platform has a some issues that this project tries (or will try) to solve:
+- Each club has its own website and app to book the courts, so you need to check all the websites 1 by 1 to find the available courts.
+- The website only shows the available courts for 1 day, so you need to check day by day to find the available courts.
+- Don't have any filter to find only the available courts, so you need to navigate through all the courts to find the available ones.
 
-The motivation for this project was just to have fun and to not forget about python since I'm not using it these months. But also I wanted to play around [Flask](https://flask.palletsprojects.com/en/2.0.x/) and [BeautifulSoup](https://www.crummy.com/software/BeautifulSoup/bs4/doc/) since I never used them before. Also I must recognice that every time I go back to Valencia and I want to play padel [Playtomic](https://www.playtomic.io/) is always empty since every club is using their own website and apps to book the courts, so I wanted to create a tool that could help me to see all the available courts in one place.
+The motivation for this project was just to have fun and to not forget about python since I'm not using it these months. But also I wanted to play around [Flask](https://flask.palletsprojects.com/en/2.0.x/) and [BeautifulSoup](https://www.crummy.com/software/BeautifulSoup/bs4/doc/) since I never used these before. Also I must recognice that every time I go back to Valencia and I want to play padel [Playtomic](https://www.playtomic.io/) is always empty since every club is using their own website and apps to book the courts, so I wanted to create a tool that could help me to see all the available courts in one place.
 
 ## Table of Contents
 
@@ -118,7 +121,19 @@ The Flask app should now be accessible at `http://localhost:8000/docs/`.
 
 Honestly, this is a project that I did in a couple of hours just to entertain myself and to not forget about python since is my main language but I'm not using it these months. But if you want to contribute, feel free to do it. Just fork the repository, make your changes and submit a pull request.
 
-Maybe would be interesting to extract some other information like statistics about wich courts are more used, sport is played the most, etc.
-Or would be interesting to see all the available courts for the different websites like [Playtomic](https://www.playtomic.io/), maybe even create a web that implements this api.
+Maybe would be interesting to extract some other information like statistics about wich courts are more used, sport is played the most, etc. (Done)
+Or would be interesting to see all the available courts for the different websites like [Playtomic](https://www.playtomic.io/). (Also Done 🤭)
+Would be super cool to create a web that implements this api.
+Also there are *modern* alternatives to [Webs de padel](https://www.websdepadel.com/) like [Matchpoint By Matchi](https://tpcmatchpoint.com/) that could be interesting to scrape and show in the same place.
 
-Also take in mind that the website is quite old and padel clubs are moving to other platform so this project could be deprecated soon.
+Take in mind that the [Webs de padel](https://www.websdepadel.com/) platform is quite old and padel clubs are moving to other platform so this project could be deprecated soon.
+
+### TODO
+- [x] Scrape websites from [Webs de padel](https://www.websdepadel.com/) platform.
+- [ ] Create and updatable db to easily increase the number of clubs (currently is hardcoded).
+- [ ] Improve the way filters are defined (currently is hardcoded, each club has different sports).
+- [ ] To improve Swagger documentation would be nice to use models and arguments definitions in the good way.
+- [ ] Add the capability to filter by geolocation (I should even force this since the amount of clubs is increasing and I don't want to DDOS the websites).
+- [ ] Cache the results to avoid scraping the websites every time (At least for half an hour, same reason as before).
+- [ ] Parallelize the scraping to make it faster.
+- [ ] Create a web that implements this api.

--- a/app/api/availability.py
+++ b/app/api/availability.py
@@ -2,7 +2,7 @@ from flask import Response, g, jsonify
 from flask_restx import Namespace, Resource, reqparse
 
 from app.models import MatchFilter
-from app.services.availability import scrap_court_data
+from app.services.availability import get_court_data
 
 ns = Namespace("availability", description="See court availability")
 
@@ -31,5 +31,5 @@ class CourtAvailability(Resource):
             is_available=args.get("is_available"),
             days=args.get("days", "0123456"),
         )
-        data = scrap_court_data(filter, g.site)
+        data = get_court_data(filter, g.sites)
         return jsonify([match.model_dump() for match in data])

--- a/app/api/errors.py
+++ b/app/api/errors.py
@@ -9,6 +9,10 @@ def handle_validation_error(e: ValidationError) -> tuple[dict, int]:
     return {"error": "validation_error", "message": json.loads(e.json(include_url=False, include_context=False))}, 400
 
 
+def handle_value_error(e: ValueError) -> tuple[dict, int]:
+    return {"error": "value_error", "message": str(e)}, 400
+
+
 def handle_http_exception(e: HTTPException) -> tuple[dict, int]:
     return {"error": "http_exception", "message": e.description or e.name}, e.code or 500
 
@@ -19,5 +23,6 @@ def handle_internal_error(e: Exception) -> tuple[dict, int]:
 
 def init_error_handlers(api: Api) -> None:
     api.error_handlers[ValidationError] = handle_validation_error  # type: ignore
+    api.error_handlers[ValueError] = handle_value_error  # type: ignore
     api.error_handlers[HTTPException] = handle_http_exception  # type: ignore
     api.error_handlers[Exception] = handle_internal_error  # type: ignore

--- a/app/api/greedy_players.py
+++ b/app/api/greedy_players.py
@@ -21,5 +21,5 @@ class GreedyPlayers(Resource):
         """Return the list of players that will be playing the most in the next 7 days"""
         args = greedy_players_parser.parse_args()
         filter = GreedyPlayersFilter(sport=str(args.get("sport")))
-        data = scrap_greedy_players(filter, g.site)
+        data = scrap_greedy_players(filter, g.sites)
         return jsonify(data)

--- a/app/api/routes.py
+++ b/app/api/routes.py
@@ -11,7 +11,7 @@ authorizations = {
         "type": "apiKey",
         "in": "header",
         "name": "X-SITE",
-        "description": "Optional header to specify the site. Default: esportentavernesblanques.es",
+        "description": "Optional header to specify the site. Default: All known sites.",
     }
 }
 api = Api(

--- a/app/api/tested_sites.py
+++ b/app/api/tested_sites.py
@@ -1,11 +1,7 @@
 from flask import Response, jsonify
 from flask_restx import Namespace, Resource
 
-SUPPORTED_SITES = [
-    "esportentavernesblanques.es",
-    "ialesport.com",
-    "padelgymclub.com",  # greedy players not supported
-]
+from app.services.sites import get_sites
 
 ns = Namespace("tested sites", description="Get the list of supported sites and last update (may be outdated)")
 
@@ -14,9 +10,4 @@ ns = Namespace("tested sites", description="Get the list of supported sites and 
 class TestedSites(Resource):
     def get(self) -> Response:
         """Get the list of supported sites and last update (may be outdated)"""
-        return jsonify(
-            {
-                "sites": SUPPORTED_SITES,
-                "last_update": "2024-06-11",
-            }
-        )
+        return jsonify(get_sites().model_dump())

--- a/app/api/usage.py
+++ b/app/api/usage.py
@@ -60,7 +60,7 @@ class SportUsage(Resource):
         """See sport usage"""
         args = usage_parser.parse_args()
         filter = MatchFilter(sport=args.get("sport"), days=args.get("days", "0123456"))
-        data = get_court_usage(filter, g.site).model_dump()
+        data = get_court_usage(filter, g.sites).model_dump()
         for sport in data["sports"]:
             for court in sport["courts"]:
                 court.pop("matches")

--- a/app/middleware.py
+++ b/app/middleware.py
@@ -2,9 +2,12 @@ from typing import Callable
 
 from flask import g, request
 
+from app.services.sites import SUPPORTED_SITES, find_site_by_url_or_unknown
 
-def site_middleware(default_site: str = "esportentavernesblanques.es") -> Callable:
+
+def site_middleware() -> Callable:
     def middleware() -> None:
-        g.site = request.headers.get("X-SITE", default_site)
+        site_url = request.headers.get("X-SITE")
+        g.sites = [find_site_by_url_or_unknown(site_url)] if site_url else SUPPORTED_SITES
 
     return middleware

--- a/app/models.py
+++ b/app/models.py
@@ -3,6 +3,17 @@ import re
 from pydantic import BaseModel, Field, computed_field, field_validator
 
 
+class SiteInfo(BaseModel):
+    name: str
+    url: str
+    coordinates: tuple[float, float] | None = None
+
+
+class AvailableSitesResponse(BaseModel):
+    sites: list[SiteInfo]
+    last_update: str
+
+
 class MatchInfo(BaseModel):
     sport: str
     court: str
@@ -10,6 +21,7 @@ class MatchInfo(BaseModel):
     time: str
     url: str
     is_available: bool
+    site: SiteInfo
 
 
 class MatchFilter(BaseModel):

--- a/app/services/sites.py
+++ b/app/services/sites.py
@@ -1,0 +1,49 @@
+from app.models import AvailableSitesResponse, SiteInfo
+
+SUPPORTED_SITES = [
+    SiteInfo(
+        name="Esport en Tavernes Blanques",
+        url="esportentavernesblanques.es",
+        coordinates=(39.494, -0.384),
+    ),
+    SiteInfo(
+        name="Iale Esport",
+        url="ialesport.com",
+        coordinates=(39.545, -0.461),
+    ),
+    SiteInfo(
+        name="Padel Gym Club",
+        url="padelgymclub.com",
+        coordinates=(39.476, -0.368),
+    ),
+    SiteInfo(
+        name="Desafio Pádel",
+        url="desafiopadel.com",
+        coordinates=(39.474, -0.368),
+    ),
+    SiteInfo(
+        name="XV Pádel",
+        url="xvpadel.com",
+        coordinates=(39.476, -0.368),
+    ),
+    SiteInfo(
+        name="XTD Pádel",
+        url="padelparccentralxtd.com",
+        coordinates=(39.476, -0.368),
+    ),
+    SiteInfo(
+        name="Muro Club de Tenis y Pádel",
+        url="ctplaplana.com",
+        coordinates=(39.545, -0.461),
+    ),
+]
+
+SITES_BY_URL = {site.url: site for site in SUPPORTED_SITES}
+
+
+def find_site_by_url_or_unknown(url: str) -> SiteInfo:
+    return SITES_BY_URL.get(url, SiteInfo(name="Unknown", url=url))
+
+
+def get_sites() -> AvailableSitesResponse:
+    return AvailableSitesResponse(sites=SUPPORTED_SITES, last_update="2024-06-15")

--- a/app/services/usage.py
+++ b/app/services/usage.py
@@ -1,9 +1,18 @@
-from app.models import CourtUsage, Match, MatchFilter, SportUsage, UsageResponse
-from app.services.availability import scrap_court_data
+from app.models import (
+    CourtUsage,
+    Match,
+    MatchFilter,
+    SiteInfo,
+    SportUsage,
+    UsageResponse,
+)
+from app.services.availability import get_court_data
 
 
-def get_court_usage(filter: MatchFilter, site: str) -> UsageResponse:
-    court_data = scrap_court_data(filter, site)
+def get_court_usage(filter: MatchFilter, sites: list[SiteInfo]) -> UsageResponse:
+    if len(sites) != 1:
+        raise ValueError("Please provide only one site by using X-SITE header")
+    court_data = get_court_data(filter, sites)
 
     response = UsageResponse(sports=[])
     for match in court_data:

--- a/tests/api/test_availability.py
+++ b/tests/api/test_availability.py
@@ -5,29 +5,36 @@ from flask import Response
 from app.models import MatchInfo
 
 
-@patch("app.api.availability.scrap_court_data")
+@patch("app.api.availability.get_court_data")
 def test_get_returns_response(mock_scrap_court_data, client) -> None:
     mock_scrap_court_data.return_value = []
     response = client.get("/api/availability/?sport=padel")
     assert isinstance(response, Response)
 
 
-@patch("app.api.availability.scrap_court_data")
-def test_get_returns_json_response_with_court_data(mock_scrap_court_data, client) -> None:
+@patch("app.api.availability.get_court_data")
+def test_get_returns_json_response_with_court_data(mock_scrap_court_data, client, example_site) -> None:
     """Information returned by the API is the same as the one returned by the scrap_court_data service
     so this is straightforward to test."""
 
     mock_scrap_court_data.return_value = [
         MatchInfo(
-            sport="padel", court="Court 1", date="2024-06-11", time="10:00", url="http://example.com", is_available=True
+            sport="padel",
+            court="Court 1",
+            date="2024-06-11",
+            time="10:00",
+            url="http://example.com/match1",
+            is_available=True,
+            site=example_site,
         ),
         MatchInfo(
             sport="tenis",
             court="Court 2",
             date="2024-06-12",
             time="12:00",
-            url="http://example.com",
+            url="http://example.com/match2",
             is_available=False,
+            site=example_site,
         ),
     ]
 
@@ -40,11 +47,11 @@ def test_get_returns_json_response_with_court_data(mock_scrap_court_data, client
     assert json_data[0]["court"] == "Court 1"
     assert json_data[0]["date"] == "2024-06-11"
     assert json_data[0]["time"] == "10:00"
-    assert json_data[0]["url"] == "http://example.com"
+    assert json_data[0]["url"] == "http://example.com/match1"
     assert json_data[0]["is_available"] is True
     assert json_data[1]["sport"] == "tenis"
     assert json_data[1]["court"] == "Court 2"
     assert json_data[1]["date"] == "2024-06-12"
     assert json_data[1]["time"] == "12:00"
-    assert json_data[1]["url"] == "http://example.com"
+    assert json_data[1]["url"] == "http://example.com/match2"
     assert json_data[1]["is_available"] is False

--- a/tests/api/test_tested_sites.py
+++ b/tests/api/test_tested_sites.py
@@ -1,7 +1,7 @@
 from flask import Response
 from flask.testing import FlaskClient
 
-from app.api.tested_sites import SUPPORTED_SITES
+from app.services.sites import get_sites
 
 
 def test_get_returns_response(client: FlaskClient) -> None:
@@ -13,8 +13,4 @@ def test_get_returns_json_response_with_supported_sites_and_last_update(client: 
     response = client.get("/api/tested-sites/")
     json_data = response.get_json()
 
-    assert isinstance(json_data, dict)
-    assert "sites" in json_data
-    assert "last_update" in json_data
-    assert json_data["sites"] == SUPPORTED_SITES
-    assert json_data["last_update"] == "2024-06-11"
+    assert sorted(json_data) == sorted(get_sites().model_dump())

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,6 +6,7 @@ from flask.testing import FlaskClient
 
 from app import create_app
 from app.middleware import site_middleware
+from app.models import SiteInfo
 
 
 @pytest.fixture
@@ -25,3 +26,8 @@ def app() -> Iterable[Flask]:
 @pytest.fixture
 def client(app: Flask) -> FlaskClient:
     return app.test_client()
+
+
+@pytest.fixture
+def example_site() -> SiteInfo:
+    return SiteInfo(url="example.com", name="Example Site")

--- a/tests/services/test_availability.py
+++ b/tests/services/test_availability.py
@@ -2,59 +2,51 @@ from datetime import datetime, timedelta
 from unittest.mock import Mock, patch
 
 from freezegun import freeze_time
+from pytest import fixture
 
-from app.models import MatchFilter, MatchInfo
-from app.services.availability import check_filters, scrap_court_data
+from app.models import MatchFilter, MatchInfo, SiteInfo
+from app.services.availability import check_filters, get_court_data, scrap_court_data
 
 
 @freeze_time("2024-06-11")
 class TestCheckFilters:
-    def test_check_filters_sport_matching(self):
-        match_info = MatchInfo(
-            sport="padel", court="Court 1", date="2024-06-11", time="10:00", url="http://example.com", is_available=True
-        )
-        match_filter = MatchFilter(sport="padel", is_available=None, days="0123456")
-        assert check_filters(match_info, match_filter) is True
-
-    def test_check_filters_sport_not_matching(self):
-        match_info = MatchInfo(
-            sport="tenis", court="Court 1", date="2024-06-11", time="10:00", url="http://example.com", is_available=True
-        )
-        match_filter = MatchFilter(sport="padel", is_available=None, days="0123456")
-        assert check_filters(match_info, match_filter) is False
-
-    def test_check_filters_availability_matching(self):
-        match_info = MatchInfo(
-            sport="padel", court="Court 1", date="2024-06-11", time="10:00", url="http://example.com", is_available=True
-        )
-        match_filter = MatchFilter(sport="padel", is_available=True, days="0123456")
-        assert check_filters(match_info, match_filter) is True
-
-    def test_check_filters_availability_not_matching(self):
-        match_info = MatchInfo(
+    @fixture
+    def match_info(self, example_site) -> MatchInfo:
+        return MatchInfo(
             sport="padel",
             court="Court 1",
             date="2024-06-11",
             time="10:00",
-            url="http://example.com",
-            is_available=False,
+            url="http://example.com/match1",
+            is_available=True,
+            site=example_site,
         )
-        match_filter = MatchFilter(sport="padel", is_available=True, days="0123456")
+
+    def test_check_filters_sport_matching(self, match_info):
+        match_filter = MatchFilter(sport="padel", is_available=None, days="0123456")
+        assert check_filters(match_info, match_filter) is True
+
+    def test_check_filters_sport_not_matching(self, match_info):
+        match_info.sport = "tenis"
+        match_filter = MatchFilter(sport="padel", is_available=None, days="0123456")
         assert check_filters(match_info, match_filter) is False
 
-    def test_check_filters_date_not_past(self):
-        future_date = (datetime.now() + timedelta(days=1)).strftime("%Y-%m-%d")
-        match_info = MatchInfo(
-            sport="padel", court="Court 1", date=future_date, time="10:00", url="http://example.com", is_available=True
-        )
+    def test_check_filters_availability_matching(self, match_info):
         match_filter = MatchFilter(sport="padel", is_available=True, days="0123456")
         assert check_filters(match_info, match_filter) is True
 
-    def test_check_filters_date_past(self):
-        past_date = (datetime.now() - timedelta(days=1)).strftime("%Y-%m-%d")
-        match_info = MatchInfo(
-            sport="padel", court="Court 1", date=past_date, time="10:00", url="http://example.com", is_available=True
-        )
+    def test_check_filters_availability_not_matching(self, match_info):
+        match_info.is_available = False
+        match_filter = MatchFilter(sport="padel", is_available=True, days="0123456")
+        assert check_filters(match_info, match_filter) is False
+
+    def test_check_filters_date_not_past(self, match_info):
+        match_info.date = (datetime.now() + timedelta(days=1)).strftime("%Y-%m-%d")
+        match_filter = MatchFilter(sport="padel", is_available=True, days="0123456")
+        assert check_filters(match_info, match_filter) is True
+
+    def test_check_filters_date_past(self, match_info):
+        match_info.date = (datetime.now() - timedelta(days=1)).strftime("%Y-%m-%d")
         match_filter = MatchFilter(sport="padel", is_available=True, days="0123456")
         assert check_filters(match_info, match_filter) is False
 
@@ -92,10 +84,13 @@ class TestScrapCourtData:
         </li>
     </div>
     """
-    SITE = "fakesite.com"
+
+    @fixture
+    def sites(self):
+        return [SiteInfo(url="example.com", name="Example"), SiteInfo(url="test.com", name="Test")]
 
     @patch("app.services.availability.requests.get")
-    def test_scrap_court_data(self, mock_requests_get):
+    def test_scrap_court_data(self, mock_requests_get, example_site):
         """Returns all matches from the HTML content."""
         mock_response = Mock()
         mock_response.status_code = 200
@@ -103,7 +98,7 @@ class TestScrapCourtData:
         mock_requests_get.return_value = mock_response
 
         match_filter = MatchFilter(days="0")
-        result = scrap_court_data(match_filter, self.SITE)
+        result = scrap_court_data(match_filter, example_site)
 
         assert len(result) == 4
         assert result[0].sport == "Padel"
@@ -136,7 +131,7 @@ class TestScrapCourtData:
 
     @patch("app.services.availability.requests.get")
     @freeze_time("2024-06-11 12:00")
-    def test_scrap_court_data_filters_past_date(self, mock_requests_get):
+    def test_scrap_court_data_filters_past_date(self, mock_requests_get, example_site):
         """Returns only matches that are not in the past."""
         mock_response = Mock()
         mock_response.status_code = 200
@@ -144,7 +139,7 @@ class TestScrapCourtData:
         mock_requests_get.return_value = mock_response
 
         match_filter = MatchFilter(days="0")
-        result = scrap_court_data(match_filter, self.SITE)
+        result = scrap_court_data(match_filter, example_site)
 
         assert len(result) == 2
 
@@ -159,7 +154,7 @@ class TestScrapCourtData:
         assert result[1].time == "14:00"
 
     @patch("app.services.availability.requests.get")
-    def test_scrap_court_data_filter_by_sport(self, mock_requests_get):
+    def test_scrap_court_data_filter_by_sport(self, mock_requests_get, example_site):
         """Returns only matches that match the sport filter."""
         mock_response = Mock()
         mock_response.status_code = 200
@@ -168,12 +163,12 @@ class TestScrapCourtData:
 
         # Filter by sport "tenis"
         filter_tenis = MatchFilter(sport="tenis", is_available=None, days="0")
-        result = scrap_court_data(filter_tenis, self.SITE)
+        result = scrap_court_data(filter_tenis, example_site)
         assert len(result) == 1
         assert result[0].sport == "Tenis"
 
     @patch("app.services.availability.requests.get")
-    def test_scrap_court_data_filter_by_availability(self, mock_requests_get):
+    def test_scrap_court_data_filter_by_availability(self, mock_requests_get, example_site):
         """Returns only matches that match the availability filter."""
         mock_response = Mock()
         mock_response.status_code = 200
@@ -182,18 +177,18 @@ class TestScrapCourtData:
 
         # Filter by availability False
         filter_not_available = MatchFilter(is_available=False, days="0")
-        result = scrap_court_data(filter_not_available, self.SITE)
+        result = scrap_court_data(filter_not_available, example_site)
         assert len(result) == 1
         assert result[0].is_available is False
 
         # Filter by availability True
         filter_available = MatchFilter(is_available=True, days="0")
-        result = scrap_court_data(filter_available, self.SITE)
+        result = scrap_court_data(filter_available, example_site)
         assert len(result) == 3
         assert all(match.is_available is True for match in result)
 
     @patch("app.services.availability.requests.get")
-    def test_scrap_court_data_filter_by_days(self, mock_requests_get):
+    def test_scrap_court_data_filter_by_days(self, mock_requests_get, example_site):
         """Returns only matches that match the days filter."""
         mock_response = Mock()
         mock_response.status_code = 200
@@ -201,16 +196,71 @@ class TestScrapCourtData:
         mock_requests_get.return_value = mock_response
 
         filter_days_1 = MatchFilter(days="01", sport="Tenis", is_available=None)
-        result = scrap_court_data(filter_days_1, self.SITE)
+        result = scrap_court_data(filter_days_1, example_site)
         assert len(result) == 2
         assert result[0].date == "2024-06-11"
         assert result[1].date == "2024-06-12"
 
         filter_days_2 = MatchFilter(days="23456", sport="Tenis", is_available=None)
-        result = scrap_court_data(filter_days_2, self.SITE)
+        result = scrap_court_data(filter_days_2, example_site)
         assert len(result) == 5
         assert result[0].date == "2024-06-13"
         assert result[1].date == "2024-06-14"
         assert result[2].date == "2024-06-15"
         assert result[3].date == "2024-06-16"
         assert result[4].date == "2024-06-17"
+
+    @patch("app.services.availability.scrap_court_data")
+    def test_get_court_data_calls(self, mock_scrap_court_data, sites):
+        sites = [SiteInfo(url="example.com", name="Example"), SiteInfo(url="test.com", name="Test")]
+        get_court_data(MatchFilter(days="0"), sites)
+        assert mock_scrap_court_data.call_count == 2
+
+    @patch("app.services.availability.scrap_court_data")
+    def test_get_court_data_sorts(self, mock_scrap_court_data, sites):
+        """Sorts the matches by date and time."""
+        match1 = MatchInfo(
+            sport="padel",
+            court="Court 1",
+            date="2024-06-12",
+            time="10:00",
+            url="http://example.com/match1",
+            is_available=True,
+            site=sites[0],
+        )
+        match2 = MatchInfo(
+            sport="padel",
+            court="Court 2",
+            date="2024-06-11",
+            time="12:00",
+            url="http://example.com/match2",
+            is_available=True,
+            site=sites[0],
+        )
+        match3 = MatchInfo(
+            sport="padel",
+            court="Court 3",
+            date="2024-06-12",
+            time="11:00",
+            url="http://example.com/match3",
+            is_available=True,
+            site=sites[0],
+        )
+        match4 = MatchInfo(
+            sport="padel",
+            court="Court 4",
+            date="2024-06-11",
+            time="13:00",
+            url="http://example.com/match4",
+            is_available=True,
+            site=sites[0],
+        )
+
+        mock_scrap_court_data.return_value = [match1, match2, match3, match4]
+        response = get_court_data(MatchFilter(days="0"), [sites[0]])
+
+        assert len(response) == 4
+        assert response[0].court == "Court 2"
+        assert response[1].court == "Court 4"
+        assert response[2].court == "Court 1"
+        assert response[3].court == "Court 3"

--- a/tests/services/test_usage.py
+++ b/tests/services/test_usage.py
@@ -1,5 +1,7 @@
 from unittest.mock import patch
 
+import pytest
+
 from app.models import (
     CourtUsage,
     Match,
@@ -11,12 +13,36 @@ from app.models import (
 from app.services.usage import get_court_usage
 
 
-@patch("app.services.usage.scrap_court_data")
-def test_get_court_usage(mock_scrap_court_data) -> None:
-    mock_scrap_court_data.return_value = [
-        MatchInfo(sport="padel", court="Court 1", date="2024-06-12", time="10:00", url="_", is_available=True),
-        MatchInfo(sport="padel", court="Court 1", date="2024-06-12", time="11:00", url="_", is_available=False),
-        MatchInfo(sport="padel", court="Court 2", date="2024-06-12", time="10:00", url="_", is_available=False),
+@patch("app.services.usage.get_court_data")
+def test_get_court_usage(get_court_data, example_site) -> None:
+    get_court_data.return_value = [
+        MatchInfo(
+            sport="padel",
+            court="Court 1",
+            date="2024-06-12",
+            time="10:00",
+            url="_",
+            is_available=True,
+            site=example_site,
+        ),
+        MatchInfo(
+            sport="padel",
+            court="Court 1",
+            date="2024-06-12",
+            time="11:00",
+            url="_",
+            is_available=False,
+            site=example_site,
+        ),
+        MatchInfo(
+            sport="padel",
+            court="Court 2",
+            date="2024-06-12",
+            time="10:00",
+            url="_",
+            is_available=False,
+            site=example_site,
+        ),
         MatchInfo(
             sport="tenis",
             court="Court 3",
@@ -24,10 +50,11 @@ def test_get_court_usage(mock_scrap_court_data) -> None:
             time="12:00",
             url="_",
             is_available=False,
+            site=example_site,
         ),
     ]
 
-    result = get_court_usage(MatchFilter(days="0"), "site.com")
+    result = get_court_usage(MatchFilter(days="0"), [example_site])
 
     expected = UsageResponse(
         sports=[
@@ -64,3 +91,10 @@ def test_get_court_usage(mock_scrap_court_data) -> None:
     )
 
     assert result == expected
+
+
+@patch("app.services.usage.get_court_data")
+def test_get_court_usage_limited_to_1_site(mock_get_court_data, example_site) -> None:
+    mock_get_court_data.return_value = []
+    with pytest.raises(ValueError):
+        get_court_usage(MatchFilter(days="0"), [example_site, example_site])

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -14,9 +14,15 @@ from app.models import (
 
 
 class TestMatchInfo:
-    def test_match_info_creation(self) -> None:
+    def test_match_info_creation(self, example_site) -> None:
         match_info = MatchInfo(
-            sport="padel", court="Court 1", date="2024-06-12", time="10:00", url="http://example.com", is_available=True
+            sport="padel",
+            court="Court 1",
+            date="2024-06-12",
+            time="10:00",
+            url="http://example.com",
+            is_available=True,
+            site=example_site,
         )
         assert match_info.sport == "padel"
         assert match_info.court == "Court 1"


### PR DESCRIPTION
Removes the default value for `esportstavernesblanques.es` and allows to scrap all *known* club data

## Some important changes
- Changed the X-SITE header middleware return value to ve a list of a new SiteInfo Model
- Added a handler for ValueErrors
- Created a service file for `sites`, moved SUPPORTED_SITES and added a few useful functions
- Added new supported sites