### PR TITLE
feat: cache to use daily fragments

### DIFF
--- a/app/api/availability.py
+++ b/app/api/availability.py
@@ -2,7 +2,6 @@ from flask import Response, jsonify
 from flask_restx import Namespace, Resource, inputs
 
 from app.api.common import headers_parser
-from app.cache import cache
 from app.context_helpers import get_sites
 from app.models import MatchFilter
 from app.services.availability import get_court_data
@@ -23,16 +22,9 @@ availability_parser.add_argument(
 )
 
 
-def get_cache_availabilty_key() -> str:
-    args = availability_parser.parse_args()
-    key = f"{args.get('sport')}-{args.get('is_available')}-{args.get('days')}-{args.get('X-SITE')}-{args.get('X-GEOLOCATION')}"
-    return key
-
-
 @ns.route("/")
 class CourtAvailability(Resource):
     @ns.expect(availability_parser)
-    @cache.cached(timeout=1800, key_prefix=get_cache_availabilty_key)
     def get(self) -> Response:
         """See court availability"""
         args = availability_parser.parse_args()

--- a/tests/services/test_availability.py
+++ b/tests/services/test_availability.py
@@ -2,7 +2,7 @@ from datetime import datetime, timedelta
 from unittest.mock import Mock, patch
 
 from freezegun import freeze_time
-from pytest import fixture
+from pytest import fixture, mark
 
 from app.models import MatchFilter, MatchInfo, SiteInfo, SiteType
 from app.services.availability import (
@@ -11,6 +11,15 @@ from app.services.availability import (
     scrap_playtomic_court_data,
     scrap_websdepadel_court_data,
 )
+
+
+@fixture(scope="class")
+def patch_cache_and_requests_class():
+    with patch("app.services.availability.cache.get") as mock_cache_get, patch(
+        "app.services.availability.cache.set"
+    ) as mock_cache_set, patch("app.services.availability.requests.get") as mock_requests_get:
+        mock_cache_get.return_value = None
+        yield mock_cache_get, mock_cache_set, mock_requests_get
 
 
 @freeze_time("2024-06-11")
@@ -57,6 +66,7 @@ class TestCheckFilters:
 
 
 @freeze_time("2024-06-20")
+@mark.usefixtures("patch_cache_and_requests_class")
 class TestScrapPlaytomicCourtData:
     @fixture
     def match_filter(self) -> MatchFilter:


### PR DESCRIPTION
### Description

This PR refactors the caching system to use daily fragments instead of a global cache for the entire call. This allows for more flexible usage, enabling other calls to partially leverage the cached data.

### Changes Made

- Refactored caching system to store data by day during 30 min.
- Updated scraping functions to use the new fragmented cache structure.

### Benefits

- **Increased Flexibility**: Allows different calls to use cached data for specific days, reducing redundant work.
- **Improved Performance**: Reduces response times for different queries by using a more granular cache approach, exact queries remain the same.

### Notes

This is a partial solutions since I'm currently testing a Android app with some friends and I don't want to DDOS any external site 😆 , must implement a better system than `SimpleCache` 💀, but by now does the trick
