### PR TITLE
feat: use app friendly links for playtomic sites

### DIFF
--- a/app/services/sites.py
+++ b/app/services/sites.py
@@ -74,7 +74,7 @@ def get_playtomic_sites(geo_filter: GeolocationFilter) -> list[SiteInfo]:
         response = request.json()
         for tenant in response:
             name = tenant["tenant_name"]
-            url = f"https://playtomic.io/{tenant['tenant_uid']}/{tenant['tenant_id']}"
+            url = f"https://playtomic.io/tenant/{tenant['tenant_id']}"
             coordinates = float(tenant["address"]["coordinate"]["lat"]), float(tenant["address"]["coordinate"]["lon"])
             sites.append(SiteInfo(name=name, url=url, coordinates=coordinates, type=SiteType.PLAYTOMIC))
     except Exception as e:  # TODO: Specify the exception type + Add lint rule to not use bare except.
@@ -87,7 +87,7 @@ def find_site_by_url_or_unknown(url: str) -> SiteInfo:
     return SITES_BY_URL.get(url, SiteInfo(name="Unknown", url=url, type=SiteType.WEBSDEPADEL))
 
 
-def get_available_sites(geo_filter: GeolocationFilter) -> AvailableSitesResponse:
+def get_available_sites(geo_filter: GeolocationFilter, with_playtomic: bool = True) -> AvailableSitesResponse:
     sites = filter_sites_by_distance(SUPPORTED_SITES, geo_filter) if geo_filter else list(SUPPORTED_SITES)
     sites.extend(get_playtomic_sites(geo_filter))
     return AvailableSitesResponse(sites=sites, last_update="2024-06-20")

--- a/tests/api/test_sites.py
+++ b/tests/api/test_sites.py
@@ -47,7 +47,7 @@ class TestGetPlaytomicSites:
 
         assert len(sites) == 1
         assert sites[0].name == "Playtomic Test Site"
-        assert sites[0].url == "https://playtomic.io/club_padel/67890"
+        assert sites[0].url == "https://playtomic.io/tenant/67890"
         assert sites[0].coordinates == (40.416775, -3.70379)
         assert sites[0].type == SiteType.PLAYTOMIC
 


### PR DESCRIPTION
### Description

This PR adds functionality to use app-friendly links for Playtomic sites. When a user on an iOS or Android device clicks the link, it will open the Playtomic app instead of the browser.

Quick example with an Android APP implementing this API



https://github.com/user-attachments/assets/7472d398-c7c1-474f-9fec-7ce4b30779c8

