### PR TITLE
feat: grouped availability results

### DIFF
--- a/app/integrations/scrapers/__init__.py
+++ b/app/integrations/scrapers/__init__.py
@@ -2,9 +2,10 @@ from app.models import SiteType
 
 from .matchpoint_scraper import MatchpointScraper
 from .playtomic_scraper import PlaytomicScraper
+from .scraper_interface import ScraperInterface
 from .websdepadel_scraper import WebsdepadelScraper
 
-SCRAPERS = {
+SCRAPERS: dict[SiteType, type[ScraperInterface]] = {
     SiteType.WEBSDEPADEL: WebsdepadelScraper,
     SiteType.PLAYTOMIC: PlaytomicScraper,
     SiteType.MATCHPOINT: MatchpointScraper,

--- a/app/integrations/scrapers/matchpoint_scraper.py
+++ b/app/integrations/scrapers/matchpoint_scraper.py
@@ -1,19 +1,14 @@
 import logging
 import re
 import unicodedata
+from datetime import datetime
 from typing import Self
 
-import requests
 from bs4 import BeautifulSoup
 
 from app.integrations.scrapers.scraper_interface import ScraperInterface
-from app.models import MatchFilter, MatchInfo, SiteInfo, SiteMatches
-from app.services.common import (
-    check_filters,
-    get_weekly_dates,
-    time_in_past,
-    time_not_in_range,
-)
+from app.models import MatchFilter, MatchInfo, SiteInfo
+from app.services.common import check_filters, time_in_past, time_not_in_range
 
 logger = logging.getLogger(__name__)
 
@@ -23,11 +18,18 @@ class MatchpointScraper(ScraperInterface):
     SPORTS_URL = "https://{site}/booking/srvc.aspx/ObtenerCuadros"
     BOOKING_URL = "https://{site}/booking/srvc.aspx/ObtenerCuadro"
 
-    def __init__(self) -> None:
-        self.session = requests.Session()
+    def __init__(self, site: SiteInfo, filter: MatchFilter) -> None:
+        super().__init__(site, filter)
+        self.session.headers.update(
+            {
+                "Referer": self.BASE_URL.format(site=site.url),
+            }
+        )
+        self.key = self._get_api_key()
+        self.sport_ids = self._get_sport_ids()
 
-    def _get_api_key(self, site: SiteInfo) -> str:
-        url = self.BASE_URL.format(site=site.url)
+    def _get_api_key(self) -> str:
+        url = self.BASE_URL.format(site=self.site.url)
         response = self.session.get(url)
         html_content = response.text
         soup = BeautifulSoup(html_content, "html.parser")
@@ -55,63 +57,44 @@ class MatchpointScraper(ScraperInterface):
                 sport_ids.append(sport["Id"])
         return sport_ids
 
-    def _get_sport_ids(self, site: SiteInfo, filter: MatchFilter, key: str) -> list[int]:
-        url = self.SPORTS_URL.format(site=site.url)
-        response = self.session.post(url, json={"key": key})
+    def _get_sport_ids(self) -> list[int]:
+        url = self.SPORTS_URL.format(site=self.site.url)
+        response = self.session.post(url, json={"key": self.key})
         response_data = response.json()
-        return self._filter_sport_ids(response_data["d"], filter)
+        return self._filter_sport_ids(response_data["d"], self.filter)
 
-    def get_court_data(self: Self, filter: MatchFilter, site: SiteInfo) -> list[SiteMatches]:
-        # TODO:
-        # - Login may be required for some sites, need to add a prior login step here
-        # - Should be able to fetch multiple sports, but we are only fetching the first one, this
-        # is because I will limit the api to filter by only one sport in further PRs
-        data: list[SiteMatches] = []
-        try:
-            key = self._get_api_key(site)
-            self.session.headers.update(
-                {
-                    "Referer": self.BASE_URL.format(site=site.url),
-                }
-            )
-            sport_ids = self._get_sport_ids(site, filter, key)
-            for date, payload_date in zip(get_weekly_dates(filter), get_weekly_dates(filter, "%d/%m/%Y")):
-                site_match = SiteMatches(site=site, date=date, matches=[])
-                cache_key = self._generate_cache_key(site, filter, date)
-                site_match.matches = self._get_cached_data(cache_key)
-                if site_match.matches:
-                    data.append(site_match)
+    def _get_scraped_availability(self: Self, date: str) -> list[dict]:
+        url = self.BOOKING_URL.format(site=self.site.url)
+        payload_date = datetime.strptime(date, "%Y-%m-%d").strftime("%d/%m/%Y")
+        payload = {"idCuadro": self.sport_ids[0], "fecha": payload_date, "key": self.key}
+        response = self.session.post(url, json=payload)
+        response_data = response.json()
+
+        if "d" not in response_data or "Columnas" not in response_data["d"]:
+            logger.error(f"Columns not found for date {date}, site {self.site.url}")
+            return []
+
+        return response_data["d"]["Columnas"]
+
+    def _get_daily_matches(self: Self, date: str) -> list[MatchInfo]:
+        data: list[MatchInfo] = []
+
+        courts = self._get_scraped_availability(date)
+        for court in courts:
+            court_name = court["TextoPrincipal"]
+            matches = court["HorariosFijos"]
+            for match in matches:
+                start_time = match["StrHoraInicio"]
+                if time_not_in_range(start_time, self.filter) or time_in_past(date, start_time):
                     continue
+                match_info = MatchInfo(
+                    sport=self.filter.sport or "padel",
+                    url=self.BASE_URL.format(site=self.site.url),
+                    time=start_time,
+                    court=court_name,
+                    is_available=True,
+                )
+                if check_filters(match_info, self.filter):
+                    data.append(match_info)
 
-                url = self.BOOKING_URL.format(site=site.url)
-                payload = {"idCuadro": sport_ids[0], "fecha": payload_date, "key": key}
-                response = self.session.post(url, json=payload)
-                response_data = response.json()
-                if "d" not in response_data or "Columnas" not in response_data["d"]:
-                    logger.error(f"Columns not found for date {date}, site {site.url}")
-                    continue
-
-                courts = response_data["d"]["Columnas"]
-                for court in courts:
-                    court_name = court["TextoPrincipal"]
-                    times = court["HorariosFijos"]
-                    for time in times:
-                        start_time = time["StrHoraInicio"]
-                        if time_not_in_range(start_time, filter) or time_in_past(date, start_time):
-                            continue
-                        match_info = MatchInfo(
-                            sport=filter.sport or "padel",
-                            url=self.BASE_URL.format(site=site.url),
-                            time=start_time,
-                            court=court_name,
-                            is_available=True,
-                        )
-                        if check_filters(match_info, filter):
-                            site_match.matches.append(match_info)
-
-                self._cache_data(cache_key, site_match.matches)
-                if site_match.matches:
-                    data.append(site_match)
-        finally:
-            self.session.close()
         return data

--- a/app/integrations/scrapers/playtomic_scraper.py
+++ b/app/integrations/scrapers/playtomic_scraper.py
@@ -2,74 +2,72 @@ from datetime import datetime, timedelta
 from typing import Self
 
 import pytz
-import requests
 
 from app.integrations.scrapers.scraper_interface import ScraperInterface
-from app.models import MatchFilter, MatchInfo, SiteInfo, SiteMatches
-from app.services.common import check_filters, get_weekly_dates
+from app.models import MatchFilter, MatchInfo, SiteInfo
+from app.services.common import check_filters
 
 
 class PlaytomicScraper(ScraperInterface):
     BASE_URL = "https://playtomic.io/api/v1/availability"
+
+    def __init__(self, site: SiteInfo, filter: MatchFilter) -> None:
+        super().__init__(site, filter)
+        self.court_friendly_names: dict[str, str] = {}
 
     def _reduce_results(self: Self, date: str, start_time: str, duration: int, used_start_times: set[str]) -> bool:
         # Artificially reduce the results to only show 90 minutes matches that start at the hour
         match_date = datetime.strptime(f"{date} {start_time}", "%Y-%m-%d %H:%M:%S")
         return match_date >= datetime.now() and duration == 90 and start_time not in used_start_times
 
-    def get_court_data(self: Self, filter: MatchFilter, site: SiteInfo) -> list[SiteMatches]:
-        data: list[SiteMatches] = []
+    def _localize_time(self: Self, date: str, start_time: str) -> str:
+        time_utc = pytz.utc.localize(datetime.strptime(f"{date} {start_time}", "%Y-%m-%d %H:%M:%S"))
+        return time_utc.astimezone(pytz.timezone("Europe/Madrid")).strftime("%H:%M")
+
+    def _friendly_court_name(self: Self, court_id: str) -> str:
+        if court_id not in self.court_friendly_names:
+            self.court_friendly_names[court_id] = f"Padel {len(self.court_friendly_names) + 1}"
+        return self.court_friendly_names[court_id]
+
+    def _get_scraped_availability(self: Self, date: str) -> list[dict]:
         params = {
             "user_id": "me",
-            "tenant_id": site.url.split("/")[-1],
+            "tenant_id": self.site.url.split("/")[-1],
             "sport_id": "PADEL",
+            "local_start_min": f"{date}T{self.filter.time_min}:00",
+            "local_start_max": f"{date}T{self.filter.time_max}:00",
         }
-        court_friendly_name: dict[str, str] = {}
-        for date in get_weekly_dates(filter):
-            site_match = SiteMatches(site=site, date=date, matches=[])
-            cache_key = self._generate_cache_key(site, filter, date)
-            site_match.matches = self._get_cached_data(cache_key)
-            if site_match.matches:
-                data.append(site_match)
-                continue
 
-            params["local_start_min"] = f"{date}T{filter.time_min}:00"
-            params["local_start_max"] = f"{date}T{filter.time_max}:00"
-            response = requests.get(self.BASE_URL, params=params)
-            if response.status_code != 200:
-                continue
+        response = self.session.get(self.BASE_URL, params=params)
+        if response.status_code != 200:
+            return []
 
-            for court in response.json():
-                # Assign a friendly name to the court instead of the uuid
-                if court["resource_id"] not in court_friendly_name:
-                    court_friendly_name[court["resource_id"]] = f"Padel {len(court_friendly_name) + 1}"
+        return response.json()
 
-                used_start_times: set[str] = set()
-                for slot in court["slots"]:
-                    if not self._reduce_results(date, slot["start_time"], slot["duration"], used_start_times):
-                        continue
+    def _get_daily_matches(self: Self, date: str) -> list[MatchInfo]:
+        data: list[MatchInfo] = []
 
-                    time = datetime.strptime(slot["start_time"], "%H:%M:%S")
-                    used_start_times.add(slot["start_time"])
-                    used_start_times.add((time + timedelta(minutes=30)).strftime("%H:%M:%S"))
-                    used_start_times.add((time + timedelta(hours=1)).strftime("%H:%M:%S"))
+        courts = self._get_scraped_availability(date)
+        for court in courts:
 
-                    # playtomic time is +00:00, so we need to convert it to the local timezone
-                    time_utc = pytz.utc.localize(datetime.strptime(f"{date} {slot['start_time']}", "%Y-%m-%d %H:%M:%S"))
-                    time_str = time_utc.astimezone(pytz.timezone("Europe/Madrid")).strftime("%H:%M")
+            used_start_times: set[str] = set()
+            for match in court["slots"]:
+                if not self._reduce_results(date, match["start_time"], match["duration"], used_start_times):
+                    continue
 
-                    match_info = MatchInfo(
-                        sport="padel",
-                        court=court_friendly_name[court["resource_id"]],
-                        time=time_str,
-                        url=site.url,
-                        is_available=True,
-                    )
-                    if check_filters(match_info, filter):
-                        site_match.matches.append(match_info)
+                time = datetime.strptime(match["start_time"], "%H:%M:%S")
+                used_start_times.add(match["start_time"])
+                used_start_times.add((time + timedelta(minutes=30)).strftime("%H:%M:%S"))
+                used_start_times.add((time + timedelta(hours=1)).strftime("%H:%M:%S"))
 
-            self._cache_data(cache_key, site_match.matches)
-            if site_match.matches:
-                data.append(site_match)
+                match_info = MatchInfo(
+                    sport="padel",
+                    court=self._friendly_court_name(court["resource_id"]),
+                    time=self._localize_time(date, match["start_time"]),
+                    url=self.site.url,
+                    is_available=True,
+                )
+                if check_filters(match_info, self.filter):
+                    data.append(match_info)
 
         return data

--- a/app/integrations/scrapers/scraper_interface.py
+++ b/app/integrations/scrapers/scraper_interface.py
@@ -1,15 +1,42 @@
 import logging
 from typing import Self
 
+import requests
+
 from app.cache import cache
 from app.models import MatchFilter, MatchInfo, SiteInfo, SiteMatches
+from app.services.common import get_weekly_dates
 
 logger = logging.getLogger(__name__)
 
 
 class ScraperInterface:
-    def get_court_data(self: Self, filter: MatchFilter, site: SiteInfo) -> list[SiteMatches]:
-        raise NotImplementedError
+
+    def __init__(self, site: SiteInfo, filter: MatchFilter) -> None:
+        self.site = site
+        self.filter = filter
+        self.session = requests.Session()
+
+    def get_site_matches(self: Self) -> list[SiteMatches]:
+        site_matches: list[SiteMatches] = []
+        try:
+            for date in get_weekly_dates(self.filter):
+                site_match = SiteMatches(site=self.site, date=date, matches=[])
+                cache_key = self._generate_cache_key(self.site, self.filter, date)
+                site_match.matches = self._get_cached_data(cache_key)
+                if site_match.matches:
+                    site_matches.append(site_match)
+                    continue
+
+                site_match.matches = self._get_daily_matches(date)
+
+                site_match.matches.sort(key=lambda x: (x.court, x.time))
+                self._cache_data(cache_key, site_match.matches)
+                if site_match.matches:
+                    site_matches.append(site_match)
+        finally:
+            self.session.close()
+        return site_matches
 
     def _generate_cache_key(self: Self, site: SiteInfo, filter: MatchFilter, date: str) -> str:
         return f"{site.url}-{filter.sport}-{filter.is_available}-{date}-{filter.time_min}-{filter.time_max}"
@@ -23,3 +50,6 @@ class ScraperInterface:
     def _cache_data(self: Self, cache_key: str, data: list[MatchInfo]) -> None:
         cache.set(cache_key, data, timeout=1800)
         logger.debug(f"Data cached with key: {cache_key} for 30 minutes")
+
+    def _get_daily_matches(self: Self, date: str) -> list[MatchInfo]:
+        raise NotImplementedError

--- a/app/integrations/scrapers/scraper_interface.py
+++ b/app/integrations/scrapers/scraper_interface.py
@@ -2,13 +2,13 @@ import logging
 from typing import Self
 
 from app.cache import cache
-from app.models import MatchFilter, MatchInfo, SiteInfo
+from app.models import MatchFilter, MatchInfo, SiteInfo, SiteMatches
 
 logger = logging.getLogger(__name__)
 
 
 class ScraperInterface:
-    def get_court_data(self: Self, filter: MatchFilter, site: SiteInfo) -> list[MatchInfo]:
+    def get_court_data(self: Self, filter: MatchFilter, site: SiteInfo) -> list[SiteMatches]:
         raise NotImplementedError
 
     def _generate_cache_key(self: Self, site: SiteInfo, filter: MatchFilter, date: str) -> str:

--- a/app/integrations/scrapers/websdepadel_scraper.py
+++ b/app/integrations/scrapers/websdepadel_scraper.py
@@ -1,61 +1,47 @@
 from typing import Self
 
-import requests
 from bs4 import BeautifulSoup, Tag
 
 from app.integrations.scrapers.scraper_interface import ScraperInterface
-from app.models import MatchFilter, MatchInfo, SiteInfo, SiteMatches
-from app.services.common import (
-    check_filters,
-    get_weekly_dates,
-    time_in_past,
-    time_not_in_range,
-)
+from app.models import MatchInfo
+from app.services.common import check_filters, time_in_past, time_not_in_range
 
 
 class WebsdepadelScraper(ScraperInterface):
     BASE_URL = "https://www.{site}/partidas/{date}#contenedor-partidas"
 
-    def get_court_data(self: Self, filter: MatchFilter, site: SiteInfo) -> list[SiteMatches]:
-        data: list[SiteMatches] = []
-        for date in get_weekly_dates(filter):
-            site_match = SiteMatches(site=site, date=date, matches=[])
-            cache_key = self._generate_cache_key(site, filter, date)
-            site_match.matches = self._get_cached_data(cache_key)
-            if site_match.matches:
-                data.append(site_match)
-                continue
+    def _get_scraped_availability(self: Self, date: str) -> Tag | None:
+        url = self.BASE_URL.format(site=self.site.url, date=date)
+        response = self.session.get(url)
+        soup = BeautifulSoup(response.text, "html.parser")
+        availability = soup.find("div", id="resumen-disponibilidad")
 
-            url = self.BASE_URL.format(site=site.url, date=date)
-            response = requests.get(url)
-            soup = BeautifulSoup(response.text, "html.parser")
+        return availability if isinstance(availability, Tag) else None
 
-            availability = soup.find("div", id="resumen-disponibilidad")
-            if not availability or not isinstance(availability, Tag):
-                continue
+    def _get_daily_matches(self: Self, date: str) -> list[MatchInfo]:
+        data: list[MatchInfo] = []
 
-            sports = availability.find_all("li", class_="deporte")
-            for sport in sports:
-                sport_name = sport.find("span", class_="nombre").get_text(strip=True)
-                courts = sport.find_all("li", class_="pista")
-                for court in courts:
-                    court_name = court.find("span", class_="nombre").get_text(strip=True)
-                    matchs = court.find_all("li", class_="partida")
-                    for match in matchs:
-                        start_time = match.find("a").get_text(strip=True)
-                        if time_not_in_range(start_time, filter) or time_in_past(date, start_time):
-                            continue
-                        match_info = MatchInfo(
-                            sport=sport_name,
-                            court=court_name,
-                            time=start_time,
-                            url=match.find("a")["href"],
-                            is_available="partida-reservada" not in match["class"],
-                        )
-                        if check_filters(match_info, filter):
-                            site_match.matches.append(match_info)
+        availability = self._get_scraped_availability(date)
 
-            self._cache_data(cache_key, site_match.matches)
-            if site_match.matches:
-                data.append(site_match)
+        sports = availability.find_all("li", class_="deporte") if availability else []
+        for sport in sports:
+            sport_name = sport.find("span", class_="nombre").get_text(strip=True)
+            courts = sport.find_all("li", class_="pista")
+            for court in courts:
+                court_name = court.find("span", class_="nombre").get_text(strip=True)
+                matches = court.find_all("li", class_="partida")
+                for match in matches:
+                    start_time = match.find("a").get_text(strip=True)
+                    if time_not_in_range(start_time, self.filter) or time_in_past(date, start_time):
+                        continue
+                    match_info = MatchInfo(
+                        sport=sport_name,
+                        court=court_name,
+                        time=start_time,
+                        url=match.find("a")["href"],
+                        is_available="partida-reservada" not in match["class"],
+                    )
+                    if check_filters(match_info, self.filter):
+                        data.append(match_info)
+
         return data

--- a/app/integrations/scrapers/websdepadel_scraper.py
+++ b/app/integrations/scrapers/websdepadel_scraper.py
@@ -4,20 +4,26 @@ import requests
 from bs4 import BeautifulSoup, Tag
 
 from app.integrations.scrapers.scraper_interface import ScraperInterface
-from app.models import MatchFilter, MatchInfo, SiteInfo
-from app.services.common import check_filters, get_weekly_dates, time_not_in_range
+from app.models import MatchFilter, MatchInfo, SiteInfo, SiteMatches
+from app.services.common import (
+    check_filters,
+    get_weekly_dates,
+    time_in_past,
+    time_not_in_range,
+)
 
 
 class WebsdepadelScraper(ScraperInterface):
     BASE_URL = "https://www.{site}/partidas/{date}#contenedor-partidas"
 
-    def get_court_data(self: Self, filter: MatchFilter, site: SiteInfo) -> list[MatchInfo]:
-        data = []
+    def get_court_data(self: Self, filter: MatchFilter, site: SiteInfo) -> list[SiteMatches]:
+        data: list[SiteMatches] = []
         for date in get_weekly_dates(filter):
+            site_match = SiteMatches(site=site, date=date, matches=[])
             cache_key = self._generate_cache_key(site, filter, date)
-            daily_matches = self._get_cached_data(cache_key)
-            if daily_matches:
-                data.extend(daily_matches)
+            site_match.matches = self._get_cached_data(cache_key)
+            if site_match.matches:
+                data.append(site_match)
                 continue
 
             url = self.BASE_URL.format(site=site.url, date=date)
@@ -36,21 +42,20 @@ class WebsdepadelScraper(ScraperInterface):
                     court_name = court.find("span", class_="nombre").get_text(strip=True)
                     matchs = court.find_all("li", class_="partida")
                     for match in matchs:
-                        time = match.find("a").get_text(strip=True)
-                        if time_not_in_range(time, filter.time_min, filter.time_max):
+                        start_time = match.find("a").get_text(strip=True)
+                        if time_not_in_range(start_time, filter) or time_in_past(date, start_time):
                             continue
                         match_info = MatchInfo(
                             sport=sport_name,
                             court=court_name,
-                            date=date,
-                            time=match.find("a").get_text(strip=True),
+                            time=start_time,
                             url=match.find("a")["href"],
                             is_available="partida-reservada" not in match["class"],
-                            site=site,
                         )
                         if check_filters(match_info, filter):
-                            daily_matches.append(match_info)
+                            site_match.matches.append(match_info)
 
-            self._cache_data(cache_key, daily_matches)
-            data.extend(daily_matches)
+            self._cache_data(cache_key, site_match.matches)
+            if site_match.matches:
+                data.append(site_match)
         return data

--- a/app/models.py
+++ b/app/models.py
@@ -3,7 +3,7 @@ from datetime import datetime, timedelta
 from enum import Enum
 from typing import Self
 
-from pydantic import BaseModel, Field, field_validator, model_validator
+from pydantic import BaseModel, field_validator, model_validator
 
 
 class SiteType(str, Enum):
@@ -30,11 +30,16 @@ class AvailableSitesResponse(BaseModel):
 class MatchInfo(BaseModel):
     sport: str
     court: str
-    date: str
     time: str
     url: str
     is_available: bool
+
+
+class SiteMatches(BaseModel):
     site: SiteInfo
+    date: str
+    distance_km: float = 0
+    matches: list[MatchInfo]
 
 
 class GeolocationFilter(BaseModel):
@@ -112,45 +117,3 @@ class MatchFilter(BaseModel):
             if time_max_dt < time_min_dt:
                 raise ValueError("time_max must be greater than time_min")
         return self
-
-
-class GreedyPlayerInfo(BaseModel):
-    name: str = ""
-    count: int = 0
-    dates: set[str] = Field(default_factory=set)
-    hours: list[str] = Field(default_factory=list)
-
-    @property
-    def different_dates(self) -> int:
-        return len(self.dates)
-
-
-class GreedyPlayersFilter(BaseModel):
-    sport: str = "padel"
-    days: str = "0123456"
-
-    @field_validator("sport", mode="before")
-    @classmethod
-    def validate_sport(cls, value: str) -> str:
-        VALID_SPORTS = ["tenis", "tenis-dura", "padel", "futbol-sala", "fronton"]
-        if value not in VALID_SPORTS:
-            raise ValueError(f"sport must be one of {VALID_SPORTS}")
-        return value
-
-    @field_validator("days", mode="before")
-    @classmethod
-    def validate_days(cls, value: str) -> str:
-        if not re.match(r"^[0-6]*$", value):
-            raise ValueError("days must be a string containing digits 0-6 only")
-        if len(set(value)) != len(value):
-            raise ValueError("days must have unique digits")
-        int_days = sorted([int(d) for d in value])
-        if not all(0 <= d <= 6 for d in int_days):
-            raise ValueError("days must have digits between 0 and 6")
-        return value
-
-
-class Match(BaseModel):
-    date: str
-    time: str
-    is_available: bool

--- a/app/services/availability.py
+++ b/app/services/availability.py
@@ -1,11 +1,28 @@
+from geopy.distance import distance
+
 from app.integrations.scrapers import SCRAPERS
-from app.models import MatchFilter, MatchInfo, SiteInfo
+from app.models import GeolocationFilter, MatchFilter, SiteInfo, SiteMatches
 
 
-def get_court_data(filter: MatchFilter, sites: list[SiteInfo]) -> list[MatchInfo]:
-    data: list[MatchInfo] = []
+def add_distance_to_site_matches(
+    site_match: SiteMatches, geolocation_filter: GeolocationFilter, site: SiteInfo
+) -> None:
+    site_match.distance_km = distance(
+        (geolocation_filter.latitude, geolocation_filter.longitude),
+        site.coordinates,
+    ).km
+
+
+def get_court_data(
+    filter: MatchFilter, sites: list[SiteInfo], geolocation_filter: GeolocationFilter | None = None
+) -> list[SiteMatches]:
+    data: list[SiteMatches] = []
     for site in sites:
-        data.extend(SCRAPERS[site.type]().get_court_data(filter, site))
+        site_matches = SCRAPERS[site.type]().get_court_data(filter, site)
+        if geolocation_filter:
+            for site_match in site_matches:
+                add_distance_to_site_matches(site_match, geolocation_filter, site)
+        data.extend(site_matches)
 
-    data.sort(key=lambda x: (x.date, x.time))
+    data.sort(key=lambda x: (x.date, x.distance_km))
     return data

--- a/app/services/availability.py
+++ b/app/services/availability.py
@@ -18,7 +18,7 @@ def get_court_data(
 ) -> list[SiteMatches]:
     data: list[SiteMatches] = []
     for site in sites:
-        site_matches = SCRAPERS[site.type]().get_court_data(filter, site)
+        site_matches = SCRAPERS[site.type](site, filter).get_site_matches()
         if geolocation_filter:
             for site_match in site_matches:
                 add_distance_to_site_matches(site_match, geolocation_filter, site)

--- a/app/services/common.py
+++ b/app/services/common.py
@@ -16,14 +16,19 @@ def check_filters(match_info: MatchInfo, match_filter: MatchFilter) -> bool:
         return False
     if match_filter.is_available is not None and match_info.is_available != match_filter.is_available:
         return False
-    match_datetime = f"{match_info.date} {match_info.time}"
-    if match_datetime < datetime.now().strftime("%Y-%m-%d %H:%M"):
-        return False
+
     return True
 
 
-def time_not_in_range(match_time: str, time_min: str, time_max: str) -> bool:
+def time_in_past(date: str, time: str) -> bool:
+    match_datetime = datetime.strptime(f"{date} {time}", "%Y-%m-%d %H:%M")
+    current_datetime = datetime.now()
+
+    return match_datetime < current_datetime
+
+
+def time_not_in_range(match_time: str, filter: MatchFilter) -> bool:
     dt_match_time = datetime.strptime(match_time, "%H:%M")
-    dt_time_min = datetime.strptime(time_min, "%H:%M")
-    dt_time_max = datetime.strptime(time_max, "%H:%M")
+    dt_time_min = datetime.strptime(filter.time_min, "%H:%M")
+    dt_time_max = datetime.strptime(filter.time_max, "%H:%M")
     return not (dt_time_min <= dt_match_time <= dt_time_max)

--- a/tests/integrations/scrapers/test_matchpoint_scraper.py
+++ b/tests/integrations/scrapers/test_matchpoint_scraper.py
@@ -49,60 +49,59 @@ class TestMatchpointScrapCourtData:
             SiteInfo(url="test.com", name="Test", type=SiteType.MATCHPOINT),
         ]
 
-    @patch("app.integrations.scrapers.matchpoint_scraper.requests.Session.get")
-    def test_get_api_key(self, mock_requests_get):
+    @patch.object(MatchpointScraper, "_get_sport_ids", return_value=[4, 5])
+    @patch("app.integrations.scrapers.scraper_interface.requests.Session.get")
+    def test_get_api_key(self, mock_requests_get, _):
         site = SiteInfo(url="example.com", name="Example", type=SiteType.MATCHPOINT)
-        scraper = MatchpointScraper()
+        filter = MatchFilter(days="0", time_min="10:00", time_max="13:00")
 
         mock_response = Mock()
         mock_response.text = self.BOOKING_HTML
-
         mock_requests_get.return_value = mock_response
 
         expected_api_key = "c00lk3y=="
 
-        api_key = scraper._get_api_key(site)
+        scraper = MatchpointScraper(site, filter)
 
-        assert api_key == expected_api_key
+        assert scraper.key == expected_api_key
         mock_requests_get.assert_called_once_with("https://example.com/Booking/Grid.aspx")
 
-    @patch("app.integrations.scrapers.matchpoint_scraper.requests.Session.get")
+    @patch("app.integrations.scrapers.scraper_interface.requests.Session.get")
     def test_get_api_key_value_error(self, mock_requests_get):
         site = SiteInfo(url="example.com", name="Example", type=SiteType.MATCHPOINT)
-        scraper = MatchpointScraper()
+        filter = MatchFilter(days="0", time_min="10:00", time_max="13:00")
 
         mock_response = Mock()
         mock_response.text = "Invent"
         mock_requests_get.return_value = mock_response
 
         with pytest.raises(ValueError) as exc_info:
-            scraper._get_api_key(site)
+            MatchpointScraper(site, filter)
             assert str(exc_info.value) == "hl90njda2b89k key not found"
 
-    @patch("app.integrations.scrapers.matchpoint_scraper.requests.Session.post")
-    def test_get_sport_ids(self, mock_requests_post):
+    @patch.object(MatchpointScraper, "_get_api_key", return_value="c00lk3y==")
+    @patch("app.integrations.scrapers.scraper_interface.requests.Session.post")
+    def test_get_sport_ids(self, mock_requests_post, _):
         site = SiteInfo(url="example.com", name="Example", type=SiteType.MATCHPOINT)
-        scraper = MatchpointScraper()
+        filter = MatchFilter(days="0", time_min="10:00", time_max="13:00")
 
         mock_response = Mock()
         mock_response.json.return_value = self.SPORT_LIST_RESPONSE
-
         mock_requests_post.return_value = mock_response
 
         expected_sport_ids = [5, 4]
-        match_filter = MatchFilter(days="0", time_min="10:00", time_max="13:00")
 
-        sport_ids = scraper._get_sport_ids(site, match_filter, "c00lk3y==")
+        scraper = MatchpointScraper(site, filter)
 
-        assert sport_ids == expected_sport_ids
+        assert scraper.sport_ids == expected_sport_ids
         mock_requests_post.assert_called_once_with(
             "https://example.com/booking/srvc.aspx/ObtenerCuadros", json={"key": "c00lk3y=="}
         )
 
-    @patch("app.integrations.scrapers.matchpoint_scraper.requests.Session.post")
-    def test_get_sport_ids_filter_by_sport(self, mock_requests_post):
+    @patch.object(MatchpointScraper, "_get_api_key", return_value="c00lk3y==")
+    @patch("app.integrations.scrapers.scraper_interface.requests.Session.post")
+    def test_get_sport_ids_filter_by_sport(self, mock_requests_post, _):
         site = SiteInfo(url="example.com", name="Example", type=SiteType.MATCHPOINT)
-        scraper = MatchpointScraper()
 
         mock_response = Mock()
         mock_response.json.return_value = self.SPORT_LIST_RESPONSE
@@ -111,33 +110,30 @@ class TestMatchpointScrapCourtData:
 
         padel_filter = MatchFilter(days="0", time_min="10:00", time_max="13:00", sport="padel")
         tenis_filter = MatchFilter(days="0", time_min="10:00", time_max="13:00", sport="tenis")
+        padel_scraper = MatchpointScraper(site, padel_filter)
+        tenis_scraper = MatchpointScraper(site, tenis_filter)
 
-        tenis_sport_ids = scraper._get_sport_ids(site, tenis_filter, "c00lk3y==")
-        padel_sport_ids = scraper._get_sport_ids(site, padel_filter, "c00lk3y==")
+        assert tenis_scraper.sport_ids == [5]
+        assert padel_scraper.sport_ids == [4]
 
-        assert tenis_sport_ids == [5]
-        assert padel_sport_ids == [4]
-
-    @patch("app.integrations.scrapers.matchpoint_scraper.requests.Session.post")
-    def test_get_sport_ids_filter_by_sport_not_found(self, mock_requests_post):
+    @patch.object(MatchpointScraper, "_get_api_key", return_value="c00lk3y==")
+    @patch("app.integrations.scrapers.scraper_interface.requests.Session.post")
+    def test_get_sport_ids_filter_by_sport_not_found(self, mock_requests_post, _):
         site = SiteInfo(url="example.com", name="Example", type=SiteType.MATCHPOINT)
-        scraper = MatchpointScraper()
+        filter = MatchFilter(days="0", time_min="10:00", time_max="13:00", sport="pickleball or something worse")
 
         mock_response = Mock()
         mock_response.json.return_value = self.SPORT_LIST_RESPONSE
 
         mock_requests_post.return_value = mock_response
 
-        match_filter = MatchFilter(days="0", time_min="10:00", time_max="13:00", sport="pickleball or something worse")
+        scraper = MatchpointScraper(site, filter)
+        assert scraper.sport_ids == []
 
-        sport_ids = scraper._get_sport_ids(site, match_filter, "c00lk3y==")
-        assert sport_ids == []
-
-    @patch("app.integrations.scrapers.matchpoint_scraper.requests.Session.post")
+    @patch("app.integrations.scrapers.scraper_interface.requests.Session.post")
     @patch("app.integrations.scrapers.matchpoint_scraper.MatchpointScraper._get_sport_ids")
     @patch("app.integrations.scrapers.matchpoint_scraper.MatchpointScraper._get_api_key")
-    def test_get_court_data(self, mock_get_api_key, mock_get_sport_ids, mock_requests_post, sites):
-        scraper = MatchpointScraper()
+    def test_get_site_matches(self, mock_get_api_key, mock_get_sport_ids, mock_requests_post, sites):
 
         mock_get_api_key.return_value = "c00lk3y=="
         mock_get_sport_ids.return_value = [4]
@@ -147,9 +143,10 @@ class TestMatchpointScrapCourtData:
 
         mock_requests_post.return_value = mock_response
 
-        match_filter = MatchFilter(days="0", time_min="10:00", time_max="13:00")
+        filter = MatchFilter(days="0", time_min="10:00", time_max="13:00")
 
-        result = scraper.get_court_data(match_filter, sites[0])
+        scraper = MatchpointScraper(sites[0], filter)
+        result = scraper.get_site_matches()
         matches = result[0].matches
 
         assert len(result) == 1
@@ -159,12 +156,10 @@ class TestMatchpointScrapCourtData:
         assert matches[2].time == "10:30"
 
     @freeze_time("2024-06-11 11:00")
-    @patch("app.integrations.scrapers.matchpoint_scraper.requests.Session.post")
+    @patch("app.integrations.scrapers.scraper_interface.requests.Session.post")
     @patch("app.integrations.scrapers.matchpoint_scraper.MatchpointScraper._get_sport_ids")
     @patch("app.integrations.scrapers.matchpoint_scraper.MatchpointScraper._get_api_key")
-    def test_get_court_data_past_date(self, mock_get_api_key, mock_get_sport_ids, mock_requests_post, sites):
-        scraper = MatchpointScraper()
-
+    def test_get_site_matches_past_date(self, mock_get_api_key, mock_get_sport_ids, mock_requests_post, sites):
         mock_get_api_key.return_value = "c00lk3y=="
         mock_get_sport_ids.return_value = [4]
 
@@ -173,20 +168,18 @@ class TestMatchpointScrapCourtData:
 
         mock_requests_post.return_value = mock_response
 
-        match_filter = MatchFilter(days="0", time_min="10:00", time_max="13:00")
-
-        result = scraper.get_court_data(match_filter, sites[0])
+        filter = MatchFilter(days="0", time_min="10:00", time_max="13:00")
+        scraper = MatchpointScraper(sites[0], filter)
+        result = scraper.get_site_matches()
         matches = result[0].matches
         assert len(result) == 1
         assert len(matches) == 1
         assert matches[0].time == "12:00"
 
-    @patch("app.integrations.scrapers.matchpoint_scraper.requests.Session.post")
+    @patch("app.integrations.scrapers.scraper_interface.requests.Session.post")
     @patch("app.integrations.scrapers.matchpoint_scraper.MatchpointScraper._get_sport_ids")
     @patch("app.integrations.scrapers.matchpoint_scraper.MatchpointScraper._get_api_key")
-    def test_get_court_data_filter_date(self, mock_get_api_key, mock_get_sport_ids, mock_requests_post, sites):
-        scraper = MatchpointScraper()
-
+    def test_get_site_matches_filter_date(self, mock_get_api_key, mock_get_sport_ids, mock_requests_post, sites):
         mock_get_api_key.return_value = "c00lk3y=="
         mock_get_sport_ids.return_value = [4]
 
@@ -195,9 +188,9 @@ class TestMatchpointScrapCourtData:
 
         mock_requests_post.return_value = mock_response
 
-        match_filter = MatchFilter(days="0", time_min="10:29", time_max="13:29")
-
-        result = scraper.get_court_data(match_filter, sites[0])
+        filter = MatchFilter(days="0", time_min="10:29", time_max="13:29")
+        scraper = MatchpointScraper(sites[0], filter)
+        result = scraper.get_site_matches()
         matches = result[0].matches
         assert len(result) == 1
 
@@ -205,14 +198,12 @@ class TestMatchpointScrapCourtData:
         assert matches[0].time == "12:00"
         assert matches[1].time == "10:30"
 
-    @patch("app.integrations.scrapers.matchpoint_scraper.requests.Session.post")
+    @patch("app.integrations.scrapers.scraper_interface.requests.Session.post")
     @patch("app.integrations.scrapers.matchpoint_scraper.MatchpointScraper._get_sport_ids")
     @patch("app.integrations.scrapers.matchpoint_scraper.MatchpointScraper._get_api_key")
-    def test_get_court_data_1_site_matches_per_date(
+    def test_get_site_matches_1_site_matches_per_date(
         self, mock_get_api_key, mock_get_sport_ids, mock_requests_post, sites
     ):
-        scraper = MatchpointScraper()
-
         mock_get_api_key.return_value = "c00lk3y=="
         mock_get_sport_ids.return_value = [4]
 
@@ -221,9 +212,9 @@ class TestMatchpointScrapCourtData:
 
         mock_requests_post.return_value = mock_response
 
-        match_filter = MatchFilter(days="01", time_min="10:00", time_max="13:00")
-
-        result = scraper.get_court_data(match_filter, sites[0])
+        filter = MatchFilter(days="01", time_min="10:00", time_max="13:00")
+        scraper = MatchpointScraper(sites[0], filter)
+        result = scraper.get_site_matches()
 
         assert len(result) == 2
         assert result[0].date == "2024-06-11"

--- a/tests/integrations/scrapers/test_playtomic_scraper.py
+++ b/tests/integrations/scrapers/test_playtomic_scraper.py
@@ -10,12 +10,12 @@ from app.models import MatchFilter
 @freeze_time("2024-06-20")
 @mark.usefixtures("patch_cache")
 @patch("app.integrations.scrapers.playtomic_scraper.requests.get")
-class TestScrapPlaytomicCourtData:
+class TestPlaytomicScrapCourtData:
     @fixture
     def match_filter(self) -> MatchFilter:
         return MatchFilter(days="0", time_min="12:00", time_max="15:00")
 
-    def test_scrap_playtomic_court_data(self, mock_requests_get, playtomic_site, match_filter):
+    def test_get_court_data(self, mock_requests_get, playtomic_site, match_filter):
         mock_response = Mock()
         mock_response.status_code = 200
         mock_response.json.return_value = [
@@ -36,31 +36,34 @@ class TestScrapPlaytomicCourtData:
         mock_requests_get.return_value = mock_response
 
         result = PlaytomicScraper().get_court_data(match_filter, playtomic_site)
+        assert len(result) == 1
 
-        assert len(result) == 3
-        assert result[0].sport == "padel"
-        assert result[0].court == "Padel 1"
-        assert result[0].date == "2024-06-20"
-        assert result[0].time == "12:00"
-        assert result[0].url == playtomic_site.url
-        assert result[0].is_available is True
+        site = result[0]
+        assert site.site == playtomic_site
+        assert site.date == "2024-06-20"
 
-        assert result[1].sport == "padel"
-        assert result[1].court == "Padel 1"
-        assert result[1].date == "2024-06-20"
-        assert result[1].time == "14:00"
-        assert result[1].url == playtomic_site.url
-        assert result[1].is_available is True
+        matches = result[0].matches
+        assert len(matches) == 3
+        assert matches[0].sport == "padel"
+        assert matches[0].court == "Padel 1"
+        assert matches[0].time == "12:00"
+        assert matches[0].url == playtomic_site.url
+        assert matches[0].is_available is True
 
-        assert result[2].sport == "padel"
-        assert result[2].court == "Padel 2"
-        assert result[2].date == "2024-06-20"
-        assert result[2].time == "16:00"
-        assert result[2].url == playtomic_site.url
-        assert result[2].is_available is True
+        assert matches[1].sport == "padel"
+        assert matches[1].court == "Padel 1"
+        assert matches[1].time == "14:00"
+        assert matches[1].url == playtomic_site.url
+        assert matches[1].is_available is True
+
+        assert matches[2].sport == "padel"
+        assert matches[2].court == "Padel 2"
+        assert matches[2].time == "16:00"
+        assert matches[2].url == playtomic_site.url
+        assert matches[2].is_available is True
 
     @freeze_time("2024-06-11 12:01")
-    def test_scrap_playtomic_court_data_filters_past_date(self, mock_requests_get, playtomic_site, match_filter):
+    def test_get_court_data_filters_past_date(self, mock_requests_get, playtomic_site, match_filter):
         mock_response = Mock()
         mock_response.status_code = 200
         mock_response.json.return_value = [
@@ -82,13 +85,15 @@ class TestScrapPlaytomicCourtData:
 
         result = PlaytomicScraper().get_court_data(match_filter, playtomic_site)
 
-        assert len(result) == 1
-        assert result[0].sport == "padel"
-        assert result[0].court == "Padel 2"
-        assert result[0].date == "2024-06-11"
-        assert result[0].time == "16:00"
+        matches = result[0].matches
 
-    def test_scrap_playtomic_court_data_filters_by_duration(self, mock_requests_get, playtomic_site, match_filter):
+        assert len(result) == 1
+        assert len(matches) == 1
+        assert matches[0].sport == "padel"
+        assert matches[0].court == "Padel 2"
+        assert matches[0].time == "16:00"
+
+    def test_get_court_data_filters_by_duration(self, mock_requests_get, playtomic_site, match_filter):
         mock_response = Mock()
         mock_response.status_code = 200
         mock_response.json.return_value = [
@@ -105,13 +110,15 @@ class TestScrapPlaytomicCourtData:
 
         result = PlaytomicScraper().get_court_data(match_filter, playtomic_site)
 
-        assert len(result) == 1
-        assert result[0].sport == "padel"
-        assert result[0].court == "Padel 1"
-        assert result[0].date == "2024-06-20"
-        assert result[0].time == "12:00"
+        matches = result[0].matches
 
-    def test_scrap_playtomic_court_data_filters_next_hour_slots(self, mock_requests_get, playtomic_site, match_filter):
+        assert len(result) == 1
+        assert len(matches) == 1
+        assert matches[0].sport == "padel"
+        assert matches[0].court == "Padel 1"
+        assert matches[0].time == "12:00"
+
+    def test_get_court_data_filters_next_hour_slots(self, mock_requests_get, playtomic_site, match_filter):
         mock_response = Mock()
         mock_response.status_code = 200
         mock_response.json.return_value = [
@@ -129,13 +136,14 @@ class TestScrapPlaytomicCourtData:
 
         result = PlaytomicScraper().get_court_data(match_filter, playtomic_site)
 
-        assert len(result) == 2
-        assert result[0].time == "12:00"
-        assert result[1].time == "13:30"
+        matches = result[0].matches
 
-    def test_scrap_playtomic_court_data_request_time_to_localtime(
-        self, mock_requests_get, playtomic_site, match_filter
-    ):
+        assert len(result) == 1
+        assert len(matches) == 2
+        assert matches[0].time == "12:00"
+        assert matches[1].time == "13:30"
+
+    def test_get_court_data_request_time_to_localtime(self, mock_requests_get, playtomic_site, match_filter):
         mock_response = Mock()
         mock_response.status_code = 200
         mock_response.json.return_value = [
@@ -150,5 +158,28 @@ class TestScrapPlaytomicCourtData:
 
         result = PlaytomicScraper().get_court_data(match_filter, playtomic_site)
 
+        matches = result[0].matches
+
         assert len(result) == 1
-        assert result[0].time == "12:00"
+        assert len(matches) == 1
+        assert matches[0].time == "12:00"
+
+    def test_get_court_data_1_site_matches_per_date(self, mock_requests_get, playtomic_site):
+        mock_response = Mock()
+        mock_response.status_code = 200
+        mock_response.json.return_value = [
+            {
+                "resource_id": "court1",
+                "slots": [
+                    {"start_time": "10:00:00", "duration": 90},
+                ],
+            },
+        ]
+        mock_requests_get.return_value = mock_response
+
+        match_filter = MatchFilter(days="01", time_min="12:00", time_max="15:00")
+
+        result = PlaytomicScraper().get_court_data(match_filter, playtomic_site)
+        assert len(result) == 2
+        assert result[0].date == "2024-06-20"
+        assert result[1].date == "2024-06-21"

--- a/tests/integrations/scrapers/test_websdepadel_scraper.py
+++ b/tests/integrations/scrapers/test_websdepadel_scraper.py
@@ -53,7 +53,7 @@ class TestWebsDePadelScrapCourtData:
             SiteInfo(url="test.com", name="Test", type=SiteType.WEBSDEPADEL),
         ]
 
-    def test_scrap_websdepadel_court_data(self, mock_requests_get, example_site):
+    def test_get_court_data(self, mock_requests_get, example_site):
         """Returns all matches from the HTML content."""
         mock_response = Mock()
         mock_response.status_code = 200
@@ -62,38 +62,35 @@ class TestWebsDePadelScrapCourtData:
 
         match_filter = MatchFilter(days="0", time_min="10:00", time_max="13:00")
         result = WebsdepadelScraper().get_court_data(match_filter, example_site)
+        matches = result[0].matches
 
-        assert len(result) == 4
-        assert result[0].sport == "Padel"
-        assert result[0].court == "Court 1"
-        assert result[0].date == "2024-06-11"
-        assert result[0].time == "10:00"
-        assert result[0].url == "http://example.com/match1"
-        assert result[0].is_available is True
+        assert len(matches) == 4
+        assert matches[0].sport == "Padel"
+        assert matches[0].court == "Court 1"
+        assert matches[0].time == "10:00"
+        assert matches[0].url == "http://example.com/match1"
+        assert matches[0].is_available is True
 
-        assert result[1].sport == "Padel"
-        assert result[1].court == "Court 1"
-        assert result[1].date == "2024-06-11"
-        assert result[1].time == "12:00"
-        assert result[1].url == "http://example.com/match2"
-        assert result[1].is_available is False
+        assert matches[1].sport == "Padel"
+        assert matches[1].court == "Court 1"
+        assert matches[1].time == "12:00"
+        assert matches[1].url == "http://example.com/match2"
+        assert matches[1].is_available is False
 
-        assert result[2].sport == "Padel"
-        assert result[2].court == "Court 2"
-        assert result[2].date == "2024-06-11"
-        assert result[2].time == "13:00"
-        assert result[2].url == "http://example.com/match3"
-        assert result[2].is_available is True
+        assert matches[2].sport == "Padel"
+        assert matches[2].court == "Court 2"
+        assert matches[2].time == "13:00"
+        assert matches[2].url == "http://example.com/match3"
+        assert matches[2].is_available is True
 
-        assert result[3].sport == "Tenis"
-        assert result[3].court == "Court 3"
-        assert result[3].date == "2024-06-11"
-        assert result[3].time == "10:00"
-        assert result[3].url == "http://example.com/match4"
-        assert result[3].is_available is True
+        assert matches[3].sport == "Tenis"
+        assert matches[3].court == "Court 3"
+        assert matches[3].time == "10:00"
+        assert matches[3].url == "http://example.com/match4"
+        assert matches[3].is_available is True
 
     @freeze_time("2024-06-11 12:00")
-    def test_scrap_websdepadel_court_data_filters_past_date(self, mock_requests_get, example_site):
+    def test_get_court_data_filters_past_date(self, mock_requests_get, example_site):
         """Returns only matches that are not in the past."""
         mock_response = Mock()
         mock_response.status_code = 200
@@ -102,20 +99,19 @@ class TestWebsDePadelScrapCourtData:
 
         match_filter = MatchFilter(days="0", time_min="10:00", time_max="13:00")
         result = WebsdepadelScraper().get_court_data(match_filter, example_site)
+        matches = result[0].matches
 
-        assert len(result) == 2
+        assert len(matches) == 2
 
-        assert result[0].sport == "Padel"
-        assert result[0].court == "Court 1"
-        assert result[0].date == "2024-06-11"
-        assert result[0].time == "12:00"
+        assert matches[0].sport == "Padel"
+        assert matches[0].court == "Court 1"
+        assert matches[0].time == "12:00"
 
-        assert result[1].sport == "Padel"
-        assert result[1].court == "Court 2"
-        assert result[1].date == "2024-06-11"
-        assert result[1].time == "13:00"
+        assert matches[1].sport == "Padel"
+        assert matches[1].court == "Court 2"
+        assert matches[1].time == "13:00"
 
-    def test_scrap_websdepadel_court_hour_filter(self, mock_requests_get, example_site):
+    def test_get_court_hour_filter(self, mock_requests_get, example_site):
         """Returns only matches that are not in the past."""
         mock_response = Mock()
         mock_response.status_code = 200
@@ -124,15 +120,15 @@ class TestWebsDePadelScrapCourtData:
 
         match_filter = MatchFilter(days="0", time_min="13:30", time_max="14:30")
         result = WebsdepadelScraper().get_court_data(match_filter, example_site)
+        matches = result[0].matches
 
-        assert len(result) == 1
+        assert len(matches) == 1
 
-        assert result[0].sport == "Padel"
-        assert result[0].court == "Court 2"
-        assert result[0].date == "2024-06-11"
-        assert result[0].time == "14:00"
+        assert matches[0].sport == "Padel"
+        assert matches[0].court == "Court 2"
+        assert matches[0].time == "14:00"
 
-    def test_scrap_websdepadel_court_data_filter_by_sport(self, mock_requests_get, example_site):
+    def test_get_court_data_filter_by_sport(self, mock_requests_get, example_site):
         """Returns only matches that match the sport filter."""
         mock_response = Mock()
         mock_response.status_code = 200
@@ -142,10 +138,11 @@ class TestWebsDePadelScrapCourtData:
         # Filter by sport "tenis"
         filter_tenis = MatchFilter(sport="tenis", is_available=None, days="0", time_min="10:00", time_max="13:00")
         result = WebsdepadelScraper().get_court_data(filter_tenis, example_site)
-        assert len(result) == 1
-        assert result[0].sport == "Tenis"
+        matches = result[0].matches
+        assert len(matches) == 1
+        assert matches[0].sport == "Tenis"
 
-    def test_scrap_websdepadel_court_data_filter_by_availability(self, mock_requests_get, example_site):
+    def test_get_court_data_filter_by_availability(self, mock_requests_get, example_site):
         """Returns only matches that match the availability filter."""
         mock_response = Mock()
         mock_response.status_code = 200
@@ -155,16 +152,18 @@ class TestWebsDePadelScrapCourtData:
         # Filter by availability False
         filter_not_available = MatchFilter(is_available=False, days="0", time_min="10:00", time_max="13:00")
         result = WebsdepadelScraper().get_court_data(filter_not_available, example_site)
-        assert len(result) == 1
-        assert result[0].is_available is False
+        matches = result[0].matches
+        assert len(matches) == 1
+        assert matches[0].is_available is False
 
         # Filter by availability True
         filter_available = MatchFilter(is_available=True, days="0", time_min="10:00", time_max="13:00")
         result = WebsdepadelScraper().get_court_data(filter_available, example_site)
-        assert len(result) == 3
-        assert all(match.is_available is True for match in result)
+        matches = result[0].matches
+        assert len(matches) == 3
+        assert all(match.is_available is True for match in matches)
 
-    def test_scrap_websdepadel_court_data_filter_by_days(self, mock_requests_get, example_site):
+    def test_get_court_data_filter_by_days(self, mock_requests_get, example_site):
         """Returns only matches that match the days filter."""
         mock_response = Mock()
         mock_response.status_code = 200

--- a/tests/integrations/scrapers/test_websdepadel_scraper.py
+++ b/tests/integrations/scrapers/test_websdepadel_scraper.py
@@ -9,7 +9,7 @@ from app.models import MatchFilter, SiteInfo, SiteType
 
 @freeze_time("2024-06-11")
 @mark.usefixtures("patch_cache")
-@patch("app.integrations.scrapers.websdepadel_scraper.requests.get")
+@patch("app.integrations.scrapers.scraper_interface.requests.Session.get")
 class TestWebsDePadelScrapCourtData:
     HTML_CONTENT = """
     <div id="resumen-disponibilidad">
@@ -61,7 +61,7 @@ class TestWebsDePadelScrapCourtData:
         mock_requests_get.return_value = mock_response
 
         match_filter = MatchFilter(days="0", time_min="10:00", time_max="13:00")
-        result = WebsdepadelScraper().get_court_data(match_filter, example_site)
+        result = WebsdepadelScraper(example_site, match_filter).get_site_matches()
         matches = result[0].matches
 
         assert len(matches) == 4
@@ -98,7 +98,7 @@ class TestWebsDePadelScrapCourtData:
         mock_requests_get.return_value = mock_response
 
         match_filter = MatchFilter(days="0", time_min="10:00", time_max="13:00")
-        result = WebsdepadelScraper().get_court_data(match_filter, example_site)
+        result = WebsdepadelScraper(example_site, match_filter).get_site_matches()
         matches = result[0].matches
 
         assert len(matches) == 2
@@ -119,7 +119,7 @@ class TestWebsDePadelScrapCourtData:
         mock_requests_get.return_value = mock_response
 
         match_filter = MatchFilter(days="0", time_min="13:30", time_max="14:30")
-        result = WebsdepadelScraper().get_court_data(match_filter, example_site)
+        result = WebsdepadelScraper(example_site, match_filter).get_site_matches()
         matches = result[0].matches
 
         assert len(matches) == 1
@@ -137,7 +137,7 @@ class TestWebsDePadelScrapCourtData:
 
         # Filter by sport "tenis"
         filter_tenis = MatchFilter(sport="tenis", is_available=None, days="0", time_min="10:00", time_max="13:00")
-        result = WebsdepadelScraper().get_court_data(filter_tenis, example_site)
+        result = WebsdepadelScraper(example_site, filter_tenis).get_site_matches()
         matches = result[0].matches
         assert len(matches) == 1
         assert matches[0].sport == "Tenis"
@@ -151,14 +151,14 @@ class TestWebsDePadelScrapCourtData:
 
         # Filter by availability False
         filter_not_available = MatchFilter(is_available=False, days="0", time_min="10:00", time_max="13:00")
-        result = WebsdepadelScraper().get_court_data(filter_not_available, example_site)
+        result = WebsdepadelScraper(example_site, filter_not_available).get_site_matches()
         matches = result[0].matches
         assert len(matches) == 1
         assert matches[0].is_available is False
 
         # Filter by availability True
         filter_available = MatchFilter(is_available=True, days="0", time_min="10:00", time_max="13:00")
-        result = WebsdepadelScraper().get_court_data(filter_available, example_site)
+        result = WebsdepadelScraper(example_site, filter_available).get_site_matches()
         matches = result[0].matches
         assert len(matches) == 3
         assert all(match.is_available is True for match in matches)
@@ -171,13 +171,13 @@ class TestWebsDePadelScrapCourtData:
         mock_requests_get.return_value = mock_response
 
         filter_days_1 = MatchFilter(days="01", sport="Tenis", is_available=None, time_min="10:00", time_max="13:00")
-        result = WebsdepadelScraper().get_court_data(filter_days_1, example_site)
+        result = WebsdepadelScraper(example_site, filter_days_1).get_site_matches()
         assert len(result) == 2
         assert result[0].date == "2024-06-11"
         assert result[1].date == "2024-06-12"
 
         filter_days_2 = MatchFilter(days="456", sport="Tenis", is_available=None, time_min="10:00", time_max="13:00")
-        result = WebsdepadelScraper().get_court_data(filter_days_2, example_site)
+        result = WebsdepadelScraper(example_site, filter_days_2).get_site_matches()
         assert len(result) == 3
         assert result[0].date == "2024-06-15"
         assert result[1].date == "2024-06-16"

--- a/tests/services/test_availability.py
+++ b/tests/services/test_availability.py
@@ -16,14 +16,14 @@ class TestGetCourtData:
             SiteInfo(url="test.com", name="Test", type=SiteType.PLAYTOMIC),
         ]
 
-    @patch.object(PlaytomicScraper, "get_court_data", return_value=[])
-    @patch.object(WebsdepadelScraper, "get_court_data", return_value=[])
+    @patch.object(PlaytomicScraper, "get_site_matches", return_value=[])
+    @patch.object(WebsdepadelScraper, "get_site_matches", return_value=[])
     def test_get_court_data_calls(self, mock_scrap_websdepadel_court_data, mock_scrap_playtomic_court_data, sites):
         get_court_data(MatchFilter(days="0", time_min="10:00", time_max="13:00"), sites)
         assert mock_scrap_websdepadel_court_data.call_count == 2
         assert mock_scrap_playtomic_court_data.call_count == 1
 
-    @patch.object(WebsdepadelScraper, "get_court_data")
+    @patch.object(WebsdepadelScraper, "get_site_matches")
     def test_get_court_data_sorts(self, mock_scrap_websdepadel_court_data, sites):
         """Sorts the matches by date and time."""
         match1 = MatchInfo(

--- a/tests/services/test_availability.py
+++ b/tests/services/test_availability.py
@@ -3,7 +3,7 @@ from unittest.mock import patch
 from pytest import fixture
 
 from app.integrations.scrapers import PlaytomicScraper, WebsdepadelScraper
-from app.models import MatchFilter, MatchInfo, SiteInfo, SiteType
+from app.models import MatchFilter, MatchInfo, SiteInfo, SiteMatches, SiteType
 from app.services.availability import get_court_data
 
 
@@ -29,45 +29,45 @@ class TestGetCourtData:
         match1 = MatchInfo(
             sport="padel",
             court="Court 1",
-            date="2024-06-12",
             time="10:00",
             url="http://example.com/match1",
             is_available=True,
-            site=sites[0],
         )
         match2 = MatchInfo(
             sport="padel",
             court="Court 2",
-            date="2024-06-11",
             time="12:00",
             url="http://example.com/match2",
             is_available=True,
-            site=sites[0],
         )
         match3 = MatchInfo(
             sport="padel",
             court="Court 3",
-            date="2024-06-12",
             time="11:00",
             url="http://example.com/match3",
             is_available=True,
-            site=sites[0],
         )
         match4 = MatchInfo(
             sport="padel",
             court="Court 4",
-            date="2024-06-11",
             time="13:00",
             url="http://example.com/match4",
             is_available=True,
-            site=sites[0],
         )
+        site_matches = [
+            SiteMatches(site=sites[0], date="2024-06-11", distance_km=0.0, matches=[match2, match4]),
+            SiteMatches(site=sites[0], date="2024-06-12", distance_km=0.0, matches=[match1, match3]),
+        ]
 
-        mock_scrap_websdepadel_court_data.return_value = [match1, match2, match3, match4]
+        mock_scrap_websdepadel_court_data.return_value = site_matches
         response = get_court_data(MatchFilter(days="0", time_min="10:00", time_max="13:00"), [sites[0]])
+        site_match1, site_match2 = response
+        day1_matches, day2_matches = site_match1.matches, site_match2.matches
 
-        assert len(response) == 4
-        assert response[0].court == "Court 2"
-        assert response[1].court == "Court 4"
-        assert response[2].court == "Court 1"
-        assert response[3].court == "Court 3"
+        assert len(response) == 2
+        assert len(day1_matches) == 2
+        assert len(day2_matches) == 2
+        assert day1_matches[0].court == "Court 2"
+        assert day1_matches[1].court == "Court 4"
+        assert day2_matches[0].court == "Court 1"
+        assert day2_matches[1].court == "Court 3"

--- a/tests/services/test_common.py
+++ b/tests/services/test_common.py
@@ -4,7 +4,12 @@ import pytest
 from freezegun import freeze_time
 
 from app.models import MatchFilter, MatchInfo
-from app.services.common import check_filters, get_weekly_dates
+from app.services.common import (
+    check_filters,
+    get_weekly_dates,
+    time_in_past,
+    time_not_in_range,
+)
 
 
 class TestGetWeeklyDatesMatchFilter:
@@ -25,11 +30,9 @@ class TestCheckFilters:
         return MatchInfo(
             sport="padel",
             court="Court 1",
-            date="2024-06-11",
             time="10:00",
             url="http://example.com/match1",
             is_available=True,
-            site=example_site,
         )
 
     @pytest.fixture
@@ -50,10 +53,23 @@ class TestCheckFilters:
         match_info.is_available = False
         assert check_filters(match_info, match_filter) is False
 
-    def test_check_filters_date_not_past(self, match_info, match_filter):
-        match_info.date = (datetime.now() + timedelta(days=1)).strftime("%Y-%m-%d")
-        assert check_filters(match_info, match_filter) is True
 
-    def test_check_filters_date_past(self, match_info, match_filter):
-        match_info.date = (datetime.now() - timedelta(days=1)).strftime("%Y-%m-%d")
-        assert check_filters(match_info, match_filter) is False
+@freeze_time("2024-06-11 12:00")
+class TestTimeInPast:
+    def test_time_in_past_with_past_time(self):
+        assert time_in_past("2024-06-11", "10:00") is True
+
+    def test_time_in_past_with_future_time(self):
+        assert time_in_past("2024-06-11", "13:00") is False
+
+
+class TestTimeNotInRange:
+    def test_time_not_in_range_with_time_in_range(self):
+        match_time = "12:00"
+        match_filter = MatchFilter(days="0", time_min="10:00", time_max="13:00")
+        assert time_not_in_range(match_time, match_filter) is False
+
+    def test_time_not_in_range_with_time_not_in_range(self):
+        match_time = "14:00"
+        match_filter = MatchFilter(days="0", time_min="10:00", time_max="13:00")
+        assert time_not_in_range(match_time, match_filter) is True

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,26 +1,7 @@
 import pytest
 from pydantic import ValidationError
 
-from app.models import MatchFilter, MatchInfo
-
-
-class TestMatchInfo:
-    def test_match_info_creation(self, example_site) -> None:
-        match_info = MatchInfo(
-            sport="padel",
-            court="Court 1",
-            date="2024-06-12",
-            time="10:00",
-            url="http://example.com",
-            is_available=True,
-            site=example_site,
-        )
-        assert match_info.sport == "padel"
-        assert match_info.court == "Court 1"
-        assert match_info.date == "2024-06-12"
-        assert match_info.time == "10:00"
-        assert match_info.url == "http://example.com"
-        assert match_info.is_available is True
+from app.models import GeolocationFilter, MatchFilter
 
 
 class TestMatchFilter:
@@ -74,3 +55,26 @@ class TestMatchFilter:
         with pytest.raises(ValidationError) as exc_info:
             MatchFilter(sport="padel", is_available=True, days="012", time_min="10:00", time_max="14:00")
         assert "The difference between time_min and time_max must not exceed 3 hours" in str(exc_info.value)
+
+
+class TestGeolocationFilter:
+    def test_geolocation_filter_creation_valid(self) -> None:
+        geolocation_filter = GeolocationFilter(latitude=40.4165, longitude=-3.70256, radius_km=10)
+        assert geolocation_filter.latitude == 40.4165
+        assert geolocation_filter.longitude == -3.70256
+        assert geolocation_filter.radius_km == 10
+
+    def test_geolocation_filter_invalid_latitude(self) -> None:
+        with pytest.raises(ValidationError) as exc_info:
+            GeolocationFilter(latitude=-91, longitude=-3.70256, radius_km=10)
+        assert "latitude must be between -90 and 90" in str(exc_info.value)
+
+    def test_geolocation_filter_invalid_longitude(self) -> None:
+        with pytest.raises(ValidationError) as exc_info:
+            GeolocationFilter(latitude=40.4165, longitude=-181, radius_km=10)
+        assert "longitude must be between -180 and 180" in str(exc_info.value)
+
+    def test_geolocation_filter_invalid_radius_km(self) -> None:
+        with pytest.raises(ValidationError) as exc_info:
+            GeolocationFilter(latitude=40.4165, longitude=-3.70256, radius_km=0)
+        assert "radius_km must be greater than 0" in str(exc_info.value)


### PR DESCRIPTION
## Details

- new `SiteInfo` model to group matches by Site and Date
- `availability` returns a list of `SiteInfo` instead of `MatchInfo`, 
- new `distance_km` is returned in the response
- `availability` response is now sorted by date and distance
- Refactor `ScraperInterface` and it's implementation (just a bit)

## Extra stuff
- added missing `models` and `common` tests, also removed the useless ones.
- `SCRAPERS ` typed correctly